### PR TITLE
Remove filters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,16 +105,6 @@ const DEFAULT_OPTIONS = {
   injectLoaders: injectNoLoaders
 }
 
-function testPattern(pattern, string) {
-  if (pattern instanceof RegExp) {
-    return pattern.exec(string);
-  } else if (pattern) {
-    return pattern.match(string);
-  } else {
-    return false;
-  }
-}
-
 /**
  * Plugin which injects per-package loaders.
  *
@@ -157,10 +147,6 @@ export default class PackageLoadersPlugin {
     let resourceRelative = path.relative(packageDirname, data.resource);
     loaders = loaders
       .concat(this.options.injectLoaders(packageData, packageDirname, data.resource))
-      .filter(loader =>
-        (testPattern(loader.test, resourceRelative) ||
-         testPattern(loader.include, resourceRelative)) &&
-        !testPattern(loader.exclude, resourceRelative))
       .map(loader => resolveLoader(path.dirname(data.resource), "transform?" + loader))
       .reverse();
     loaders = await Promise.all(loaders);


### PR DESCRIPTION
They aren't in the npm version, but are in git it seems. They seem left over from the original project, and not applicable for browserify transforms. Please correct me if I'm wrong.
